### PR TITLE
Redis pub/sub 확장성 설계

### DIFF
--- a/src/main/java/chatserver/chat/controller/StompController.java
+++ b/src/main/java/chatserver/chat/controller/StompController.java
@@ -2,11 +2,13 @@ package chatserver.chat.controller;
 
 import chatserver.chat.dto.ChatMessageDto;
 import chatserver.chat.service.ChatService;
+import chatserver.chat.service.RedisPubSubService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Controller;
 
 @Slf4j
@@ -15,15 +17,26 @@ import org.springframework.stereotype.Controller;
 public class StompController {
 
     private final ChatService chatService;
-    private final SimpMessageSendingOperations messageTemplate;
+    private final RedisPubSubService redisPubSubService;
 
     @MessageMapping("/{roomId}")
-    public void sendMessage(@DestinationVariable Long roomId, ChatMessageDto chatMessageDto) {
+    public void sendMessage(@DestinationVariable Long roomId, ChatMessageDto chatMessageDto) throws JsonProcessingException {
         log.info("StompController sendMessage roomId: {}, message: {}", roomId, chatMessageDto);
         chatService.saveMessage(roomId, chatMessageDto);
+        chatMessageDto.setRoomId(roomId);
 
-        // @SendTo 어노테이션
-        messageTemplate.convertAndSend("/topic/" + roomId, chatMessageDto);
-
+        ObjectMapper objectMapper = new ObjectMapper();
+        String message = objectMapper.writeValueAsString(chatMessageDto);
+        redisPubSubService.publish("chat",message);
     }
+
+//    @MessageMapping("/{roomId}")
+//    public void sendMessage(@DestinationVariable Long roomId, ChatMessageDto chatMessageDto) {
+//        log.info("StompController sendMessage roomId: {}, message: {}", roomId, chatMessageDto);
+//        chatService.saveMessage(roomId, chatMessageDto);
+//
+//        // @SendTo 어노테이션
+//        messageTemplate.convertAndSend("/topic/" + roomId, chatMessageDto);
+//
+//    }
 }

--- a/src/main/java/chatserver/chat/dto/ChatMessageDto.java
+++ b/src/main/java/chatserver/chat/dto/ChatMessageDto.java
@@ -1,21 +1,22 @@
 package chatserver.chat.dto;
 
 import chatserver.chat.domain.ChatMessage;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
-@Getter
-@ToString
+@Data
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class ChatMessageDto {
 
+    private Long roomId;
     private String senderEmail;
     private String message;
 
     public static ChatMessageDto fromEntity(ChatMessage chatMessage) {
-        return new ChatMessageDto(chatMessage.getMember().getEmail(), chatMessage.getContent());
+        return ChatMessageDto.builder()
+                .senderEmail(chatMessage.getMember().getEmail())
+                .message(chatMessage.getContent())
+                .build();
     }
 }

--- a/src/main/java/chatserver/chat/service/RedisPubSubService.java
+++ b/src/main/java/chatserver/chat/service/RedisPubSubService.java
@@ -1,0 +1,49 @@
+package chatserver.chat.service;
+
+import chatserver.chat.dto.ChatMessageDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Service;
+
+/**
+ * 구독하기 위한 MessageListener 구현
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisPubSubService implements MessageListener {
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final SimpMessageSendingOperations messageTemplate;
+
+    /**
+     * pattern에는 topic의 이름의 패턴이 담겨있고, 이 패턴을 기반으로 동적으로 코딩 가능
+     * 우리는 패턴이 따로 없고 chat 이라고 이렇게 담겨져 있음
+     * <p>
+     * 서버1이 redis로 메시지를 보내면 redis가 서버1, 서버2한테 메시지를 줄것이고(onMessage - Message)
+     * 이걸 서버1,서버2에 있는 room1,room2에 넣어줘야함.
+     */
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        String receivedMessage = message.toString();
+        log.info("Received raw payload: {}", receivedMessage);
+        log.info("Received raw receivedMessage: {}", receivedMessage);
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            ChatMessageDto chatMessageDto = objectMapper.readValue(receivedMessage, ChatMessageDto.class);
+            messageTemplate.convertAndSend("/topic/" + chatMessageDto.getRoomId(), chatMessageDto);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void publish(String channel, String message) {
+        stringRedisTemplate.convertAndSend(channel, message);
+    }
+}

--- a/src/main/java/chatserver/common/config/RedisConfig.java
+++ b/src/main/java/chatserver/common/config/RedisConfig.java
@@ -1,0 +1,62 @@
+package chatserver.common.config;
+
+import chatserver.chat.service.RedisPubSubService;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    @Qualifier("chatPubSub")
+    public RedisConnectionFactory chatPubSubFactory() {
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
+        configuration.setHostName(host);
+        configuration.setPort(port);
+        // redis pub/sub에서는 특정 데이터베이스에 의존적이지 않음.
+//        configuration.setDatabase(0);
+        return new LettuceConnectionFactory(configuration);
+    }
+
+    @Bean
+    @Qualifier("chatPubSub")
+    public StringRedisTemplate stringRedisTemplate(@Qualifier("chatPubSub") RedisConnectionFactory redisConnectionFactory) {
+        // 일반적으로는 RedisTemplate<key,value> 사용
+        return new StringRedisTemplate(redisConnectionFactory);
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(
+            @Qualifier("chatPubSub") RedisConnectionFactory redisConnectionFactory,
+            MessageListenerAdapter messageListenerAdapter
+    ) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(redisConnectionFactory);
+        // listen하고 처리할 객체
+        container.addMessageListener(messageListenerAdapter,new PatternTopic("chat"));
+
+        return container;
+    }
+
+    // redis에서 수신된 메시지를 처리하는 객체 생성
+    @Bean
+    public MessageListenerAdapter messageListenerAdapter(RedisPubSubService redisPubSubService) {
+        // RedisPubSubService의 특정 메서드가 수신된 메시지를 처리하도록 지정
+        return new MessageListenerAdapter(redisPubSubService, "onMessage");
+    }
+}


### PR DESCRIPTION
### 1. 문제점

저희 서비스는 로드밸런서를 사용하는 멀티서버 환경이었는데 각 서버는 자신에게 연결된 사용자들의 WebSocket 세션 정보만을 메모리에 보관하고 있어서 다른 서버에 연결된 사용자에게는 직접적으로 메시지를 보낼 방법이 없었습니다.

### 2. 해결방법 - Redis pub/sub

이 문제를 해결하기 위해 Redis의 Pub/Sub 기능을 도입하여 모든 서버가 Redis를 구독하게 하여 1번 사용자가 A 서버에 메시지를 보내면, A 서버는 직접 2번 사용자를 찾으려 하지 않고 Redis에 해당 메시지를 발행하고 Redis가 자신을 구독하고 있는 A, B, C 모든 서버에게 동일한 메시지를 전파하고 각 서버는 전달받은 메시지를 확인하고, 자신에게 연결된 사용자 중에 해당 수신자가 있는지 메모리에서 확인한 후, 해당 사용자가 있으면 메시지를 전달하고 없으면 무시하는 방식으로 사용자들이 어느 서버에 연결되어 있든 상관없이 메시지를 주고받을 수 있게 해결하였습니다.

### 3. Kafka말고 Reids pub/sub을 사용한 이유
Redis는 pub/sub과정에서 메시지를 저장하지 않기에 구독하는 서버가 없다면 메시지가 유실되는 반면에 kafka는 디스크에 메시지를 저장하여 추후에라도 전송이 가능하지만 실시간 채팅으로 봤을때 Redis가 더 빠른 성능을 보장하기 때문에 채팅과 같은 실시간 서비스에서는 굉장히 유용하다고 생각했습니다.